### PR TITLE
feat: Add React code editor and execution support

### DIFF
--- a/components/CodeEditor.tsx
+++ b/components/CodeEditor.tsx
@@ -5,7 +5,7 @@ import Editor from '@monaco-editor/react';
 import { useTheme } from 'next-themes';
 
 type CodeEditorProps = {
-  language: 'html' | 'css' | 'javascript';
+  language: 'html' | 'css' | 'javascript' | 'react';
   value: string;
   onChange: (value: string) => void;
 };
@@ -14,6 +14,7 @@ const languageIcons = {
   html: FileHtml,
   css: FileCode,
   javascript: FileJson,
+  react: FileJson,
 };
 
 export function CodeEditor({ language, value, onChange }: CodeEditorProps) {


### PR DESCRIPTION
Adds a new React section to the code editor, allowing you to write and run React (JSX) code.

Key changes:
- Modified `components/CodeEditor.tsx` to support a 'react' language type.
- Updated `app/page.tsx`:
    - Introduced state management for React code.
    - Added a new CodeEditor instance for React, adjusting the layout.
    - Enhanced the `updateOutput` function to:
        - Include React, ReactDOM, and Babel (standalone) libraries in the output iframe.
        - Transpile JSX code using Babel within a `<script type="text/babel">` tag. - Render the React application into a dedicated `<div id="react-root"></div>`. - Ensure existing HTML, CSS, and plain JavaScript functionalities remain operational alongside React.
- Default React code is provided, and the console continues to capture logs from all script executions.